### PR TITLE
Depend on Java 1.8 since Dotty doesn’t support 1.9

### DIFF
--- a/dotty.rb
+++ b/dotty.rb
@@ -7,7 +7,7 @@ class Dotty < Formula
 
   bottle :unneeded
 
-  depends_on :java => "1.8+"
+  depends_on :java => "1.8"
 
   def install
     rm_f Dir["bin/*.bat"]


### PR DESCRIPTION
With this fix, brew will correctly suggest using `brew cask install caskroom/versions/java8` instead of `brew cask install java` (which install java9 and leads to a non-working Dotty).

Tested locally, committed through web interface.