### PR TITLE
Fix deprecation warning

### DIFF
--- a/dotty.rb
+++ b/dotty.rb
@@ -7,7 +7,7 @@ class Dotty < Formula
 
   bottle :unneeded
 
-  depends_on :java => "1.8+"
+  depends_on "openjdk" => "8+"
 
   def install
     rm_f Dir["bin/*.bat"]

--- a/dotty.rb
+++ b/dotty.rb
@@ -7,7 +7,7 @@ class Dotty < Formula
 
   bottle :unneeded
 
-  depends_on "openjdk" => "8+"
+  depends_on "openjdk"
 
   def install
     rm_f Dir["bin/*.bat"]


### PR DESCRIPTION
Fix the below deprecation warning shown when installing dotty:

> Warning: Calling depends_on :java is deprecated! Use "depends_on "openjdk@11", "depends_on "openjdk@8" or "depends_on "openjdk" instead.
> Please report this issue to the lampepfl/brew tap (not Homebrew/brew or Homebrew/core), or even better, submit a PR to fix it:
>   /usr/local/Homebrew/Library/Taps/lampepfl/homebrew-brew/dotty.rb:10